### PR TITLE
Migrate twins to codeberg.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Currently outdated repo mirrors:
 - [Space-Age](https://gitlab.com/lambdatronic/space-age) (Clojure) - Gemini server written in Clojure.
 - [Taurus](https://git.sr.ht/~garritfra/taurus)(Rust) - A Concurrent Gemini Server.
 - [Titan](https://github.com/jahzielv/titan) (Rust) - simple TOML-configured Gemini server and an Express-like Gemini server framework.
-- [twins](https://code.rocketnine.space/tslocum/twins) (Go) - YAML-configured Gemini server supporting vhosts, FastCGI and reverse-proxying.
+- [twins](https://codeberg.org/tslocum/twins) (Go) - YAML-configured Gemini server supporting vhosts, FastCGI and reverse-proxying.
 - [twinstar](https://github.com/panicbit/twinstar) (Rust) - gemini server implementation.
 - [vger](https://tildegit.org/solene/vger) (C) - Gemini server written in C used with inetd.
 - [Windmark](https://github.com/gemrest/windmark) (Rust) - An elegant and highly performant async Gemini server framework


### PR DESCRIPTION
Submitted by @tslocum on the upstream repo:

https://github.com/kr1sp1n/awesome-gemini/pull/240